### PR TITLE
Pin stb to a specific commit

### DIFF
--- a/com.valvesoftware.Steam.Utility.gamescope.yml
+++ b/com.valvesoftware.Steam.Utility.gamescope.yml
@@ -28,6 +28,7 @@ modules:
         commit: a15ea54ca3964f2438352b288e57dee86891b9fa
       - type: git
         url: https://github.com/nothings/stb.git
+        commit: af1a5bc352164740c1cc1354942b1c6b72eacb8a # Should be updated when updating gamescope
         dest: subprojects/stb
       - type: shell
         commands:


### PR DESCRIPTION
From the commit mesasge:
```
This should allow reproducibility.
    
Unfortunately, since Meson's git-wrap files are not supported by the
flatpak-builder workflow, we have to set the commit id manually for
now.
    
Since gamescope hasn't pinned this dependency to any specific commit
upstream, we use the latest one.
```
Suggested by @gasinvein.