### PR TITLE
Updating metainfo.xml to version 3.9.5

### DIFF
--- a/com.valvesoftware.Steam.Utility.gamescope.metainfo.xml
+++ b/com.valvesoftware.Steam.Utility.gamescope.metainfo.xml
@@ -9,6 +9,6 @@
   <project_license>BSD-2-Clause</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
-    <release version="3.9.2" date="2021-09-15"/>
+    <release version="3.9.5" date="2021-10-18"/>
   </releases>
 </component>


### PR DESCRIPTION
This change updates metainfo.xml to display the correct version "3.9.5" which was forgotten about in the last release.

The update date given is taken from the upstream gamescope release date for 3.9.5