### PR TITLE
Updated to gamescope 3.10.7 & yaml edit,  Second attempt.

### DIFF
--- a/com.valvesoftware.Steam.Utility.gamescope.yml
+++ b/com.valvesoftware.Steam.Utility.gamescope.yml
@@ -30,13 +30,6 @@ modules:
           version-scheme: semantic
           tag-pattern: "^([0-9]+.[0-9]+.[0-9]+)$"
       - type: git
-        url: https://gitlab.freedesktop.org/wayland/wayland.git
-        tag: 1.20.0
-        x-checker-data:
-          type: git
-          version-scheme: semantic
-          tag-pattern: "^([0-9]+.[0-9]+.[0-9]+)$"
-      - type: git
         url: https://github.com/nothings/stb.git
         dest: subprojects/stb
       - type: shell

--- a/com.valvesoftware.Steam.Utility.gamescope.yml
+++ b/com.valvesoftware.Steam.Utility.gamescope.yml
@@ -14,7 +14,7 @@ modules:
   - modules/libinput/libinput.json
   - modules/xwayland/xwayland.yml
   - modules/libseat/libseat.yml
-
+  
   - name: gamescope
     config-opts:
       - --wrap-mode=nodownload
@@ -24,21 +24,25 @@ modules:
     sources: &gamescope-sources
       - type: git
         url: https://github.com/Plagman/gamescope.git
-        tag: 3.9.5
-        commit: 26aeebf11d2d195fd2fa75f0d85d11dcd3ee5e69
+        tag: 3.10.7
+        commit: d22003025c0d26839621fb17d5657859cd518889
+        x-checker-data:
+          type: git
+          version-scheme: semantic
+          tag-pattern: "^([0-9]+.[0-9]+.[0-9]+)$"
       - type: git
         url: https://github.com/nothings/stb.git
-        commit: af1a5bc352164740c1cc1354942b1c6b72eacb8a # Should be updated when updating gamescope
         dest: subprojects/stb
       - type: shell
         commands:
           - install -t subprojects/stb subprojects/packagefiles/stb/*
-
+  
   - name: metadata
     buildsystem: simple
     build-commands:
       - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
-      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak
+        ${FLATPAK_ID}
     sources:
       - type: file
         path: com.valvesoftware.Steam.Utility.gamescope.metainfo.xml

--- a/com.valvesoftware.Steam.Utility.gamescope.yml
+++ b/com.valvesoftware.Steam.Utility.gamescope.yml
@@ -25,7 +25,13 @@ modules:
       - type: git
         url: https://github.com/Plagman/gamescope.git
         tag: 3.10.7
-        commit: d22003025c0d26839621fb17d5657859cd518889
+        x-checker-data:
+          type: git
+          version-scheme: semantic
+          tag-pattern: "^([0-9]+.[0-9]+.[0-9]+)$"
+      - type: git
+        url: https://gitlab.freedesktop.org/wayland/wayland.git
+        tag: 1.20.0
         x-checker-data:
           type: git
           version-scheme: semantic


### PR DESCRIPTION
##  Second attempt ... this time with validated yaml  ##

This pull request is updating: gamescope to 3.10.7

This also tries to automate the updating process via: x-checker-data
I forgot last time, but this also removes the commit hash from "github.com/nothings/stb" to help this effort.

Also, maybe?, fix to get "metainfo.xml" updating as it's supposed to.
I don't know why it's not working, the configs are near identical to other repos where it is working correctly.