### PR TITLE
upgrade to latest gamescope

### DIFF
--- a/com.valvesoftware.Steam.Utility.gamescope.metainfo.xml
+++ b/com.valvesoftware.Steam.Utility.gamescope.metainfo.xml
@@ -9,6 +9,6 @@
   <project_license>BSD-2-Clause</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
-    <release version="3.9.5" date="2021-10-18"/>
+    <release version="3.10.6" date="2022-01-18"/>
   </releases>
 </component>

--- a/com.valvesoftware.Steam.Utility.gamescope.yml
+++ b/com.valvesoftware.Steam.Utility.gamescope.yml
@@ -24,8 +24,8 @@ modules:
     sources: &gamescope-sources
       - type: git
         url: https://github.com/Plagman/gamescope.git
-        tag: 3.9.5
-        commit: 26aeebf11d2d195fd2fa75f0d85d11dcd3ee5e69
+        tag: 3.11.3
+        commit: 7b756290402a47f2ead37bcd9c641bb2c1956717
       - type: git
         url: https://github.com/nothings/stb.git
         commit: af1a5bc352164740c1cc1354942b1c6b72eacb8a # Should be updated when updating gamescope

--- a/modules/xwayland/xwayland.yml
+++ b/modules/xwayland/xwayland.yml
@@ -11,9 +11,25 @@ config-opts:
 sources:
 - type: git
   url: https://gitlab.freedesktop.org/xorg/xserver.git
-  tag: xwayland-21.1.2
-  commit: 1dbb96ae48f1fa69752e71f25f03d2f733918ffb
+  tag: xwayland-21.1.4
+  commit: fbc03d7e486e8c1e33f0c2d3ff9ed415c95de166
 modules:
+- name: wayland
+  buildsystem: meson
+  sources:
+  - type: git
+    url: https://github.com/wayland-project/wayland
+    tag: 1.20.0
+    commit: 75c1a93e2067220fa06208f20f8f096bb463ec08
+  config-opts:
+  - "-Ddocumentation=false"
+- name: libdrm
+  buildsystem: meson
+  sources:
+  - type: git
+    url: https://gitlab.freedesktop.org/mesa/drm
+    tag: libdrm-2.4.109
+    commit: febfe0addd51a48c7c9dd7fd9ddf9b5a3b5cd7c6
 - name: fontutil
   buildsystem: autotools
   sources:


### PR DESCRIPTION
* Upgrade to gamescope 3.11.3
* Upgrade to xwayland 21.1.4
* newer gamescope uses wlroots 0.15.0 which requires newer components:
  * wayland 1.20.0
  * libdrm 2.4.109