### PR TITLE
Make an empty package

### DIFF
--- a/com.valvesoftware.Steam.Utility.gamescope.metainfo.xml
+++ b/com.valvesoftware.Steam.Utility.gamescope.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="addon">
   <id>com.valvesoftware.Steam.Utility.gamescope</id>
   <extends>com.valvesoftware.Steam</extends>
-  <name>gamescope</name>
+  <name>gamescope (DEPRECATED: install org.freedesktop.Platform.VulkanLayer.gamescope)</name>
   <summary>The micro-compositor formerly known as steamcompmgr</summary>
   <url type="homepage">https://github.com/ValveSoftware/gamescope</url>
   <url type="bugtracker">https://github.com/ValveSoftware/gamescope/issues</url>

--- a/com.valvesoftware.Steam.Utility.gamescope.yml
+++ b/com.valvesoftware.Steam.Utility.gamescope.yml
@@ -5,39 +5,39 @@ runtime: com.valvesoftware.Steam
 runtime-version: stable
 build-extension: true
 appstream-compose: false
-build-options:
-  prefix: /app/utils/gamescope
-  prepend-path: /app/utils/gamescope/bin
-  append-pkg-config-path: /app/utils/gamescope/lib/pkgconfig
-  strip: true
+#build-options:
+#  prefix: /app/utils/gamescope
+#  prepend-path: /app/utils/gamescope/bin
+#  append-pkg-config-path: /app/utils/gamescope/lib/pkgconfig
+#  strip: true
 modules:
-  - modules/libinput/libinput.json
-  - modules/xwayland/xwayland.yml
-  - modules/libseat/libseat.yml
+#  - modules/libinput/libinput.json
+#  - modules/xwayland/xwayland.yml
+#  - modules/libseat/libseat.yml
 
-  - name: gamescope
-    config-opts:
-      - --wrap-mode=nodownload
-    build-options:
-      libdir: lib/x86_64-linux-gnu
-    buildsystem: meson
-    sources:
-      - type: git
-        url: https://github.com/ValveSoftware/gamescope.git
-        tag: 3.11.51
-        commit: 7aef264dfcf81c5f303422d820b7e1ecf81568f3
-        x-checker-data:
-          type: git
-          tag-pattern: ^([\d.]+)$
-          is-main-source: true
-      - type: git
-        url: https://github.com/nothings/stb.git
-        branch: master
-        commit: 5736b15f7ea0ffb08dd38af21067c314d6a3aae9 # Should be updated when updating gamescope
-        dest: subprojects/stb
-      - type: shell
-        commands:
-          - install -t subprojects/stb subprojects/packagefiles/stb/*
+#  - name: gamescope
+#    config-opts:
+#      - --wrap-mode=nodownload
+#    build-options:
+#      libdir: lib/x86_64-linux-gnu
+#    buildsystem: meson
+#    sources:
+#      - type: git
+#        url: https://github.com/ValveSoftware/gamescope.git
+#        tag: 3.11.51
+#        commit: 7aef264dfcf81c5f303422d820b7e1ecf81568f3
+#        x-checker-data:
+#          type: git
+#          tag-pattern: ^([\d.]+)$
+#          is-main-source: true
+#      - type: git
+#        url: https://github.com/nothings/stb.git
+#        branch: master
+#        commit: 5736b15f7ea0ffb08dd38af21067c314d6a3aae9 # Should be updated when updating gamescope
+#        dest: subprojects/stb
+#      - type: shell
+#        commands:
+#          - install -t subprojects/stb subprojects/packagefiles/stb/*
 
   - name: metadata
     buildsystem: simple


### PR DESCRIPTION
This package does not build anymore due to requiring newer Glibc and is causing Mesa bugs in other unrelated applications because of bundling a copy of older libdrm

So remove everything and make it clear in appdata that this is migrated

See https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1710 https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1709